### PR TITLE
Estilo de tabla de resultados

### DIFF
--- a/src/components/PensionCalculatorForm.jsx
+++ b/src/components/PensionCalculatorForm.jsx
@@ -10,11 +10,6 @@ const PensionCalculatorForm = ({ formData, errors, handleInputChange, handleSubm
   const [inicioAnio, setInicioAnio] = useState(new Date().getFullYear().toString())
   const [modalidad40Errors, setModalidad40Errors] = useState({})
 
-  /* const months = [
-    'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
-    'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'
-  ]  */
-
   const currentYear = new Date().getFullYear()
   const yearRange = Array.from({ length: 16 }, (_, i) => currentYear -5 + i)
 

--- a/src/components/PensionResults.jsx
+++ b/src/components/PensionResults.jsx
@@ -2,50 +2,57 @@ import Button from "./Button"
 
 const PensionResults = ({ results, onBack, onGeneratePDF }) => {
   return (
-    <>
-      <div className="max-w-lg mx-auto overflow-x-auto text-gray-100 pt-6 pb-8 mb-4">
-      <table className="w-full">
-        <thead>
-          <tr>
-            <th className="px-4 py-2 text-center">Edad</th>
-            <th className="px-4 py-2 text-center">%</th>
-            <th className="px-4 py-2 text-center">Pensión</th>
-            {results.pensionModalidad40 && (
-              <>
-                <th className="px-4 py-2 text-center bg-sky-800 rounded-t-md">Con Mod40</th>
-                <th className="px-4 py-2 text-center">Diferencia</th>
-              </>
-            )}
-          </tr>
-        </thead>
-        <tbody>
-          {results && results.pensionPorEdad.map((result, index) => (
-            <tr key={index} className={index % 2 === 0 ? 'bg-sky-900' : ''}>
-              <td className="border px-4 py-2 text-center whitespace-nowrap">{result.edad} años</td>
-              <td className="border px-4 py-2 text-center whitespace-nowrap">{result.porcentaje}%</td>
-              <td className="border px-4 py-2 text-center font-bold  whitespace-nowrap">${result.pension.toFixed(2)}</td>
-              {results.pensionModalidad40 && (
-                <>
-                  <td className="border px-4 py-2 text-center font-bold whitespace-nowrap bg-sky-800 text-gray-100">
-                    ${results.pensionModalidad40[index].pension.toFixed(2)}
-                  </td>
-                  <td className="border px-4 py-2 text-center whitespace-nowrap">
-                    ${(results.pensionModalidad40[index].pension - result.pension).toFixed(2)}
-                  </td>
-                </>
-              )}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-    <div className="flex justify-between max-w-lg mx-auto">
-      <div className="mt-4 flex flex-col sm:flex-row gap-4 max-w-fit mx-auto">
-        <Button onClick={onGeneratePDF} order="primary" children="Generar PDF" />
-        <Button onClick={onBack} children="Regresar" />
+    <div className="max-w-xl mx-auto px-4 py-8">
+      <div className="bg-white shadow-xl rounded-lg overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm text-center text-gray-700">
+            <thead className="text-xs uppercase bg-sky-800 text-white">
+              <tr>
+                <th className="px-6 py-3">Edad</th>
+                <th className="px-6 py-3">%</th>
+                <th className="px-6 py-3">Pensión</th>
+                {results.pensionModalidad40 && (
+                  <>
+                    <th className="px-6 py-3 bg-sky-900 whitespace-nowrap">Con Mod40</th>
+                    <th className="px-6 py-3">Diferencia</th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {results && results.pensionPorEdad.map((result, index) => (
+                <tr 
+                  key={index} 
+                  className={`${index % 2 === 0 ? 'bg-gray-50' : 'bg-white'} hover:bg-gray-100 transition-colors duration-200`}
+                >
+                  <td className="px-6 py-4 whitespace-nowrap">{result.edad} años</td>
+                  <td className="px-6 py-4 whitespace-nowrap">{result.porcentaje}%</td>
+                  <td className="px-6 py-4 whitespace-nowrap font-semibold">${result.pension.toFixed(2)}</td>
+                  {results.pensionModalidad40 && (
+                    <>
+                      <td className="px-6 py-4 whitespace-nowrap font-semibold text-sky-800">
+                        ${results.pensionModalidad40[index].pension.toFixed(2)}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-green-600">
+                        +${(results.pensionModalidad40[index].pension - result.pension).toFixed(2)}
+                      </td>
+                    </>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div className="mt-8 max-w-sm mx-auto flex justify-center space-x-4">
+        <Button onClick={onGeneratePDF} order="primary">
+          Generar PDF
+        </Button>
+        <Button onClick={onBack}>
+          Regresar
+        </Button>
       </div>
     </div>
-    </>
   )
 }
 


### PR DESCRIPTION
Se modifica estilo de tabla de resultados para resaltar las diferencias entre la pension, pension con mod40 y diferencia. 

Antes: 

![image](https://github.com/user-attachments/assets/391db9d0-3872-4cc6-8faf-b3b89ed17d5a)
![image](https://github.com/user-attachments/assets/8db91728-5d13-4c98-a74d-0c2ecc24eafe)

Después: 

![image](https://github.com/user-attachments/assets/07adef46-6235-4c63-980b-c246b24ab386)
![image](https://github.com/user-attachments/assets/5a2e25ec-d0ce-47a8-afbd-d7cf69bd37c9)
